### PR TITLE
Remove `raise` on unsupported platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
             suite: remi-php73
           - os: fedora-latest
             suite: remi-php74
+          - os: fedora-latest
+            suite: remi-php80
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the yum-remi-chef  coo
 
 ## Unreleased
 
-- Warn on unsupported platforms instead of raising error
+- Remove error on unsupported platforms
 
 ## 5.0.0 - *2021-11-03*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum-remi-chef  coo
 
 ## Unreleased
 
+- Warn on unsupported platforms instead of raising error
+
 ## 5.0.0 - *2021-11-03*
 
 - Fix support for CentOS 8 & Fedora

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The following platforms and PHP versions are supported, as per [upstream](https:
 | Amazon Linux 2  |     |     | x   | x   | x   | x   | x   | x   | x   |
 | CentOS 8        |     |     |     |     | x   | x   | x   | x   | x   |
 | CentOS Stream 8 |     |     |     |     | x   | x   | x   | x   | x   |
-| Fedora (34/35)  |     |     |     |     |     |     |     | x   | x   |
+| Fedora 34       |     |     |     |     |     |     |     | x   | x   |
+| Fedora 35       |     |     |     |     |     |     |     |     | x   |
 
 ## Recipes
 

--- a/attributes/remi-debuginfo.rb
+++ b/attributes/remi-debuginfo.rb
@@ -14,6 +14,4 @@ when 'amazon'
 when 'rhel'
   default['yum']['remi-debuginfo']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/debug-remi/$basearch/"
   default['yum']['remi-debuginfo']['description'] = "Remi's RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-debuginfo.rb
+++ b/attributes/remi-debuginfo.rb
@@ -15,5 +15,5 @@ when 'rhel'
   default['yum']['remi-debuginfo']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/debug-remi/$basearch/"
   default['yum']['remi-debuginfo']['description'] = "Remi's RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-gpgkey.rb
+++ b/attributes/remi-gpgkey.rb
@@ -21,6 +21,4 @@ default['yum-remi-chef']['gpgkey'] = case node['platform_family']
                                        else
                                          'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
                                        end
-                                     else
-                                       Chef::Log.warn("platform #{node['platform']} not recognised")
                                      end

--- a/attributes/remi-gpgkey.rb
+++ b/attributes/remi-gpgkey.rb
@@ -22,5 +22,5 @@ default['yum-remi-chef']['gpgkey'] = case node['platform_family']
                                          'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
                                        end
                                      else
-                                       raise "platform #{node['platform']} not recognised"
+                                       Chef::Log.warn("platform #{node['platform']} not recognised")
                                      end

--- a/attributes/remi-php55.rb
+++ b/attributes/remi-php55.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                  "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/php55/$basearch/mirror"
                                                end
   default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php55.rb
+++ b/attributes/remi-php55.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                                end
   default['yum']['remi-php55']['description'] = "Remi's PHP 5.5 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php56.rb
+++ b/attributes/remi-php56.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                                end
   default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php56.rb
+++ b/attributes/remi-php56.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                  "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/php56/$basearch/mirror"
                                                end
   default['yum']['remi-php56']['description'] = "Remi's PHP 5.6 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php70.rb
+++ b/attributes/remi-php70.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                  "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/php70/$basearch/mirror"
                                                end
   default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php70.rb
+++ b/attributes/remi-php70.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                                end
   default['yum']['remi-php70']['description'] = "Remi's PHP 7.0 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php71.rb
+++ b/attributes/remi-php71.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                                end
   default['yum']['remi-php71']['description'] = "Remi's PHP 7.1 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php71.rb
+++ b/attributes/remi-php71.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                  "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/php71/$basearch/mirror"
                                                end
   default['yum']['remi-php71']['description'] = "Remi's PHP 7.1 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php72.rb
+++ b/attributes/remi-php72.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                  "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/php72/$basearch/mirror"
                                                end
   default['yum']['remi-php72']['description'] = "Remi's PHP 7.2 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php72.rb
+++ b/attributes/remi-php72.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                                end
   default['yum']['remi-php72']['description'] = "Remi's PHP 7.2 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php73.rb
+++ b/attributes/remi-php73.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                                end
   default['yum']['remi-php73']['description'] = "Remi's PHP 7.3 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php73.rb
+++ b/attributes/remi-php73.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                  "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/php73/$basearch/mirror"
                                                end
   default['yum']['remi-php73']['description'] = "Remi's PHP 7.3 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php74.rb
+++ b/attributes/remi-php74.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                  "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/php74/$basearch/mirror"
                                                end
   default['yum']['remi-php74']['description'] = "Remi's PHP 7.4 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php74.rb
+++ b/attributes/remi-php74.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                                end
   default['yum']['remi-php74']['description'] = "Remi's PHP 7.4 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php80.rb
+++ b/attributes/remi-php80.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                                end
   default['yum']['remi-php80']['description'] = "Remi's PHP 8.0 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php80.rb
+++ b/attributes/remi-php80.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                  "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/php80/$basearch/mirror"
                                                end
   default['yum']['remi-php80']['description'] = "Remi's PHP 8.0 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php81.rb
+++ b/attributes/remi-php81.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                                end
   default['yum']['remi-php81']['description'] = "Remi's PHP 8.1 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-php81.rb
+++ b/attributes/remi-php81.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                  "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/php81/$basearch/mirror"
                                                end
   default['yum']['remi-php81']['description'] = "Remi's PHP 8.1 RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-safe.rb
+++ b/attributes/remi-safe.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                               end
   default['yum']['remi-safe']['description'] = "Safe Remi's RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-safe.rb
+++ b/attributes/remi-safe.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                 "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/safe/$basearch/mirror"
                                               end
   default['yum']['remi-safe']['description'] = "Safe Remi's RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-test-debuginfo.rb
+++ b/attributes/remi-test-debuginfo.rb
@@ -20,6 +20,4 @@ when 'amazon'
 when 'rhel'
   default['yum']['remi-test-debuginfo']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/debug-test/$basearch/"
   default['yum']['remi-test-debuginfo']['description'] = "Remi's test RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-test-debuginfo.rb
+++ b/attributes/remi-test-debuginfo.rb
@@ -21,5 +21,5 @@ when 'rhel'
   default['yum']['remi-test-debuginfo']['baseurl'] = "http://rpms.remirepo.net/enterprise/#{node['platform_version'].to_i}/debug-test/$basearch/"
   default['yum']['remi-test-debuginfo']['description'] = "Remi's test RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch - debuginfo"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-test.rb
+++ b/attributes/remi-test.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                               end
   default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi-test.rb
+++ b/attributes/remi-test.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                                 "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/test/$basearch/mirror"
                                               end
   default['yum']['remi-test']['description'] = "Remi's test RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi.rb
+++ b/attributes/remi.rb
@@ -21,6 +21,4 @@ when 'rhel'
                                            "http://cdn.remirepo.net/enterprise/#{node['platform_version'].to_i}/remi/$basearch/mirror"
                                          end
   default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
-else
-  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/attributes/remi.rb
+++ b/attributes/remi.rb
@@ -22,5 +22,5 @@ when 'rhel'
                                          end
   default['yum']['remi']['description'] = "Remi's RPM repository for Enterprise Linux #{node['platform_version'].to_i} - $basearch"
 else
-  raise "platform #{node['platform']} not recognised"
+  Chef::Log.warn("platform #{node['platform']} not recognised")
 end

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -194,6 +194,8 @@ suites:
         - php
       inputs:
         version: '8.0'
+    excludes:
+      - fedora-latest
 
   - name: remi-php81
     run_list:

--- a/spec/remi_php56_spec.rb
+++ b/spec/remi_php56_spec.rb
@@ -24,4 +24,12 @@ describe 'yum-remi-chef::remi-php56' do
       include_examples 'create PHP 5.6 repos'
     end
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/remi_php70_spec.rb
+++ b/spec/remi_php70_spec.rb
@@ -24,4 +24,12 @@ describe 'yum-remi-chef::remi-php70' do
       include_examples 'create PHP 7.0 repos'
     end
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/remi_php71_spec.rb
+++ b/spec/remi_php71_spec.rb
@@ -24,4 +24,12 @@ describe 'yum-remi-chef::remi-php71' do
       include_examples 'create PHP 7.1 repos'
     end
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/remi_php72_spec.rb
+++ b/spec/remi_php72_spec.rb
@@ -24,4 +24,12 @@ describe 'yum-remi-chef::remi-php72' do
       include_examples 'create PHP 7.2 repos'
     end
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/remi_php73_spec.rb
+++ b/spec/remi_php73_spec.rb
@@ -24,4 +24,12 @@ describe 'yum-remi-chef::remi-php73' do
       include_examples 'create PHP 7.3 repos'
     end
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/remi_php74_spec.rb
+++ b/spec/remi_php74_spec.rb
@@ -24,4 +24,12 @@ describe 'yum-remi-chef::remi-php74' do
       it_behaves_like 'create PHP 7.4 repos'
     end
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/remi_php80_spec.rb
+++ b/spec/remi_php80_spec.rb
@@ -24,4 +24,12 @@ describe 'yum-remi-chef::remi-php80' do
       it_behaves_like 'create PHP 8.0 repos'
     end
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/remi_php81_spec.rb
+++ b/spec/remi_php81_spec.rb
@@ -24,4 +24,12 @@ describe 'yum-remi-chef::remi-php81' do
       it_behaves_like 'create PHP 8.1 repos'
     end
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/remi_safe_spec.rb
+++ b/spec/remi_safe_spec.rb
@@ -18,4 +18,12 @@ describe 'yum-remi-chef::remi-safe' do
       include_examples 'create remi-safe repo'
     end
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/remi_spec.rb
+++ b/spec/remi_spec.rb
@@ -24,4 +24,12 @@ describe 'yum-remi-chef::remi' do
 
     include_examples 'create remi repos'
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/remi_test_spec.rb
+++ b/spec/remi_test_spec.rb
@@ -26,4 +26,12 @@ describe 'yum-remi-chef::remi-test' do
 
     include_examples 'create remi-test repos'
   end
+
+  context 'on Debian' do
+    platform 'debian'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
# Description

Since attributes are evaluated regardless of whether a dependency cookbook is included, the `raise`s introduced in #37 caused errors when in the dependency tree for unsupported platforms. 

This PR changes that error to a warning to allow for dependent cookbooks to function on non-RHEL systems. 

## Issues Resolved

Closes #38 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
