### PR TITLE
Bump yum dependency to 7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the yum-remi-chef  coo
 
 ## Unreleased
 
-- Bump `yum` dependency to `>= 5.3` for proper cache flushing on module switch
+- Bump `yum` dependency to `>= 7.3` for proper cache flushing on module switch
 
 ## 6.0.0 - *2022-01-07*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum-remi-chef  coo
 
 ## Unreleased
 
+- Bump `yum` dependency to `>= 5.3` for proper cache flushing on module switch
+
 ## 6.0.0 - *2022-01-07*
 
 - Add missing `remi-modular` repo for DNF modules

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Cookbooks
 
-- yum >= 7.2.0
+- yum >= 7.3.0
 - yum-epel
 
 ### Platforms

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-- Chef 15.3+
+- Chef 16+
 
 ### Cookbooks
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ source_url        'https://github.com/sous-chefs/yum-remi-chef'
 issues_url        'https://github.com/sous-chefs/yum-remi-chef/issues'
 chef_version      '>= 16'
 
-depends 'yum', '>= 7.2.0'  # for `dnf_module`
+depends 'yum', '>= 7.3.0'  # for `dnf_module`
 depends 'yum-epel'
 
 supports 'amazon'

--- a/test/cookbooks/test/recipes/php.rb
+++ b/test/cookbooks/test/recipes/php.rb
@@ -4,7 +4,5 @@ shortver = node['remi-test']['version'].delete('.')
 # several almost-identical test recipes
 declare_resource(:"yum_remi_php#{shortver}", 'default')
 
-# will install from remi module
-package 'php' do
-  flush_cache [:before] # dnf_module doesnt flush chef's package cache currently
-end
+# will now install from remi module
+package 'php'


### PR DESCRIPTION
# Description

This PR bumps the `yum` dependency to `>= 5.3` so that module switches work as expected. Yum 5.3 introduced cache flushing after the resource (sous-chefs/yum#196), so that users of this cookbook do not need to manually flush the package cache after adding new modules.

Also updates the README to properly reflect `metadata.rb` changes in #40.

## Issues Resolved

Fixes #41

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
