### PR TITLE
Add EL9 and PHP 8.2

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,9 +1,0 @@
-[local_phases]
-unit = "rspec spec/"
-lint = 'cookstyle --display-cop-names --extra-details'
-syntax = "echo skipping"
-provision = "echo skipping"
-deploy = "echo skipping"
-smoke = "echo skipping"
-functional = "echo skipping"
-cleanup = "echo skipping"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,44 +8,30 @@ name: ci
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
+    permissions:
+      actions: write
+      checks: write
+      pull-requests: write
+      statuses: write
+      issues: write
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
           - almalinux-8
+          - almalinux-9
           - amazonlinux-2
           - centos-7
           - centos-stream-8
+          - centos-stream-9
           - fedora-latest
           - rockylinux-8
+          - rockylinux-9
         suite:
           - 'remi'
           - 'remi-test'
@@ -57,36 +43,67 @@ jobs:
           - 'remi-php74'
           - 'remi-php80'
           - 'remi-php81'
+          - 'remi-php82'
         exclude:
           - os: almalinux-8
+            suite: remi-php56
+          - os: almalinux-9
             suite: remi-php56
           - os: amazonlinux-2
             suite: remi-php56
           - os: centos-stream-8
             suite: remi-php56
+          - os: centos-stream-9
+            suite: remi-php56
           - os: rockylinux-8
+            suite: remi-php56
+          - os: rockylinux-9
             suite: remi-php56
           - os: fedora-latest
             suite: remi-php56
           - os: almalinux-8
             suite: remi-php70
+          - os: almalinux-9
+            suite: remi-php70
           - os: centos-stream-8
+            suite: remi-php70
+          - os: centos-stream-9
             suite: remi-php70
           - os: fedora-latest
             suite: remi-php70
           - os: rockylinux-8
+            suite: remi-php70
+          - os: rockylinux-9
             suite: remi-php70
           - os: almalinux-8
             suite: remi-php71
+          - os: almalinux-9
+            suite: remi-php71
           - os: centos-stream-8
+            suite: remi-php71
+          - os: centos-stream-9
             suite: remi-php71
           - os: fedora-latest
             suite: remi-php71
           - os: rockylinux-8
             suite: remi-php71
-          - os: fedora-latest
+          - os: rockylinux-9
+            suite: remi-php71
+          - os: almalinux-9
+            suite: remi-php72
+          - os: centos-stream-9
             suite: remi-php72
           - os: fedora-latest
+            suite: remi-php72
+          - os: rockylinux-9
+            suite: remi-php72
+          - os: almalinux-9
+            suite: remi-php73
+          - os: centos-stream-9
+            suite: remi-php73
+          - os: fedora-latest
+            suite: remi-php73
+          - os: rockylinux-9
             suite: remi-php73
           - os: fedora-latest
             suite: remi-php74
@@ -96,7 +113,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Dokken

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is used to list changes made in each version of the yum-remi-chef  coo
 
 ## Unreleased
 
+- Add `remi_php82` resource for supporting PHP 8.2
+- Add support for AlmaLinux 9, CentOS Stream 9 and Rocky Linux 9
+- Remove remaining references to CentOS 8
+- Fix CI and update tests
+
 ## 6.1.1 - *2022-01-27*
 
 - Add Alma Linux and Rocky Linux to testing

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![OpenCollective](https://opencollective.com/sous-chefs/sponsors/badge.svg)](#sponsors)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 
-The yum-remi-chef cookbook takes over management of the repository ids of the [remi](http://cdn.remirepo.net/) repository . It allows attribute manipulation of `remi`, `remi-safe`, `remi-php56`, `remi-php70`, `remi-php71`, `remi-php72`, `remi-php73`, `remi-php74`, `remi-php80`, `remi-php81`, and `remi-test` repositories.
+The yum-remi-chef cookbook takes over management of the repository ids of the [remi](http://cdn.remirepo.net/) repository . It allows attribute manipulation of `remi`, `remi-safe`, `remi-php56`, `remi-php70`, `remi-php71`, `remi-php72`, `remi-php73`, `remi-php74`, `remi-php80`, `remi-php81`, `remi-php82` and `remi-test` repositories.
 
 ## Maintainers
 
@@ -27,14 +27,17 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 The following platforms and PHP versions are supported, as per [upstream](https://rpms.remirepo.net) -- `x` via a Yum repo, `M` via DNF modules:
 
-| PHP version     | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 | 7.3 | 7.4 | 8.0 | 8.1 |
-| --------------- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| CentOS 7        | x   | x   | x   | x   | x   | x   | x   | x   | x   |
-| Amazon Linux 2  |     |     | x   | x   | x   | x   | x   | x   | x   |
-| CentOS 8        |     |     |     |     | M   | M   | M   | M   | M   |
-| CentOS Stream 8 |     |     |     |     | M   | M   | M   | M   | M   |
-| Fedora 34       |     |     |     |     |     |     |     | M   | M   |
-| Fedora 35       |     |     |     |     |     |     |     |     | M   |
+| PHP version     | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 | 7.3 | 7.4 | 8.0 | 8.1 | 8.2 |
+| --------------- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| AlmaLinux 8     |     |     |     |     | M   | M   | M   | M   | M   | M   |
+| AlmaLinux 9     |     |     |     |     |     |     | M   | M   | M   | M   |
+| Amazon Linux 2  |     |     | x   | x   | x   | x   | x   | x   | x   | x   |
+| CentOS 7        | x   | x   | x   | x   | x   | x   | x   | x   | x   | x   |
+| CentOS Stream 8 |     |     |     |     | M   | M   | M   | M   | M   | M   |
+| CentOS Stream 9 |     |     |     |     |     |     | M   | M   | M   | M   |
+| Fedora (latest) |     |     |     |     |     |     |     |     | M   | M   |
+| Rocky Linux 8   |     |     |     |     | M   | M   | M   | M   | M   | M   |
+| Rocky Linux 9   |     |     |     |     |     |     | M   | M   | M   | M   |
 
 ## Recipes
 
@@ -52,7 +55,15 @@ Same function as the above recipes, but as resources instead.
 - [`yum_remi_safe`](documentation/remi_safe.md)
 - [`yum_remi_test`](documentation/remi_test.md)
 - [`yum_remi_modular`](documentation/remi_modular.md)
-- `yum_remi_phpXX` -- see the corresponding resource under [`documentation/`](documentation/)
+- [`yum_remi_php56`](documentation/remi_php56.md)
+- [`yum_remi_php70`](documentation/remi_php70.md)
+- [`yum_remi_php71`](documentation/remi_php71.md)
+- [`yum_remi_php72`](documentation/remi_php72.md)
+- [`yum_remi_php73`](documentation/remi_php73.md)
+- [`yum_remi_php74`](documentation/remi_php74.md)
+- [`yum_remi_php80`](documentation/remi_php80.md)
+- [`yum_remi_php81`](documentation/remi_php81.md)
+- [`yum_remi_php82`](documentation/remi_php82.md)
 
 ## Contributors
 

--- a/documentation/remi_php82.md
+++ b/documentation/remi_php82.md
@@ -1,0 +1,35 @@
+[Back to resource list](../README.md#resources)
+
+# `yum_remi_php82`
+
+Adds the `remi-php82` repo to the YUM / DNF repo list.
+
+> ⚠ This repo **overrides** the system PHP packages!
+
+## Actions
+
+| Action    | Description                    |
+| --------- | ------------------------------ |
+| `:create` | Creates the repo configuration |
+
+## Properties
+
+These properties are passed through to `yum_repository`. More information on these properties can be found on [the Chef docs for `yum_repository`](https://docs.chef.io/resources/yum_repository/).
+
+| Name                | Type            | Default                                                                   |
+| ------------------- | --------------- | ------------------------------------------------------------------------- |
+| `baseurl`           | `String`        | Platform specific, see [`remi_repo_baseurl`](../libraries/helpers.rb)     |
+| `mirrorlist`        | `String`        | Platform specific, see [`remi_repo_mirrorlist`](../libraries/helpers.rb)  |
+| `description`       | `String`        | Platform specific, see [`remi_repo_description`](../libraries/helpers.rb) |
+| `enabled`           | `true`, `false` | `true`                                                                    |
+| `debug_baseurl`     | `String`        | Platform specific, see [`remi_repo_baseurl`](../libraries/helpers.rb)     |
+| `debug_description` | `String`        | Platform specific, see [`remi_repo_description`](../libraries/helpers.rb) |
+| `debug_enabled`     | `true`, `false` | `false`                                                                   |
+| `gpgkey`            | `String`        | Platform specific, see [`remi_gpg_key`](../libraries/helpers.rb)          |
+| `gpgcheck`          | `true`, `false` | `true`                                                                    |
+
+## Examples
+
+```ruby
+yum_remi_php82 'default'
+```

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -20,6 +20,11 @@ platforms:
       image: dokken/almalinux-8
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: almalinux-9
+    driver:
+      image: dokken/almalinux-9
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2
@@ -35,6 +40,11 @@ platforms:
       image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: centos-stream-9
+    driver:
+      image: dokken/centos-stream-9
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest
@@ -43,4 +53,9 @@ platforms:
   - name: rockylinux-8
     driver:
       image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-9
+    driver:
+      image: dokken/rockylinux-9
       pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,11 +18,14 @@ verifier:
 
 platforms:
   - name: almalinux-8
+  - name: almalinux-9
   - name: amazonlinux-2
   - name: centos-7
   - name: centos-stream-8
+  - name: centos-stream-9
   - name: fedora-latest
   - name: rockylinux-8
+  - name: rockylinux-9
 
 suites:
   - name: remi
@@ -74,11 +77,13 @@ suites:
         version: '5.6'
     excludes:
       - almalinux-8
+      - almalinux-9
       - amazonlinux-2
-      - centos-8
       - centos-stream-8
+      - centos-stream-9
       - fedora-latest
       - rockylinux-8
+      - rockylinux-9
 
   - name: remi-php70
     run_list:
@@ -95,10 +100,12 @@ suites:
         version: '7.0'
     excludes:
       - almalinux-8
-      - centos-8
+      - almalinux-9
       - centos-stream-8
+      - centos-stream-9
       - fedora-latest
       - rockylinux-8
+      - rockylinux-9
 
   - name: remi-php71
     run_list:
@@ -115,10 +122,12 @@ suites:
         version: '7.1'
     excludes:
       - almalinux-8
-      - centos-8
+      - almalinux-9
       - centos-stream-8
+      - centos-stream-9
       - fedora-latest
       - rockylinux-8
+      - rockylinux-9
 
   - name: remi-php72
     run_list:
@@ -134,7 +143,10 @@ suites:
       inputs:
         version: '7.2'
     excludes:
+      - almalinux-9
+      - centos-stream-9
       - fedora-latest
+      - rockylinux-9
 
   - name: remi-php73
     run_list:
@@ -150,7 +162,10 @@ suites:
       inputs:
         version: '7.3'
     excludes:
+      - almalinux-9
+      - centos-stream-9
       - fedora-latest
+      - rockylinux-9
 
   - name: remi-php74
     run_list:
@@ -197,3 +212,17 @@ suites:
         - php
       inputs:
         version: '8.1'
+
+  - name: remi-php82
+    run_list:
+      - recipe[test::php]
+    attributes:
+      remi-test:
+        version: '8.2'
+    verifier:
+      controls:
+        - remi
+        - remi-safe
+        - php
+      inputs:
+        version: '8.2'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -24,10 +24,13 @@ module YumRemiChef
           # Use CentOS 7 key
           'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
         when 'rhel'
-          if node['platform_version'].to_i == 7
+          case node['platform_version'].to_i
+          when 7
             'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
-          else
+          when 8
             'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
+          when 9
+            'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
           end
         end
       end

--- a/recipes/remi-php82.rb
+++ b/recipes/remi-php82.rb
@@ -1,0 +1,27 @@
+#
+# Author:: Lance Albertson (<lance@osuosl.org>)
+# Recipe:: yum-remi-chef::remi-php82
+#
+# Copyright:: 2022, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+yum_remi_php82 'default' do
+  baseurl node['yum']['remi-php82']['baseurl']
+  gpgcheck node['yum']['remi-php82']['gpgcheck']
+  enabled node['yum']['remi-php82']['enabled']
+  mirrorlist node['yum']['remi-php82']['mirrorlist']
+  description node['yum']['remi-php82']['description']
+  gpgkey node['yum-remi-chef']['gpgkey']
+  only_if { node['yum']['remi-php82']['managed'] }
+end

--- a/resources/remi_php82.rb
+++ b/resources/remi_php82.rb
@@ -1,0 +1,46 @@
+provides :yum_remi_php82
+unified_mode true
+
+use '_partials/_common'
+
+property :baseurl, String, default: lazy { remi_repo_baseurl('php82') }
+property :mirrorlist, String, default: lazy { remi_repo_mirrorlist('php82') }
+property :description, String, default: lazy { remi_repo_description('php82') }
+
+property :debug_baseurl, String, default: lazy { remi_repo_baseurl('debug-php82') }
+property :debug_description, String, default: lazy { remi_repo_description('debug-php82') }
+
+action_class do
+  include YumRemiChef::Cookbook::Helpers
+end
+
+action :create do
+  yum_remi 'default'
+
+  # use repo on C7
+  if rhel_7_or_amazon?
+    yum_repository 'remi-php82' do
+      baseurl new_resource.baseurl
+      mirrorlist new_resource.mirrorlist
+      description new_resource.description
+      enabled new_resource.enabled
+      gpgcheck new_resource.gpgcheck
+      gpgkey new_resource.gpgkey
+      # amazon base repo has priority 10, need to override to get the correct php version
+      priority '9' if amazon?
+    end
+
+    yum_repository 'remi-php82-debuginfo' do
+      baseurl new_resource.debug_baseurl
+      description new_resource.debug_description
+      enabled new_resource.debug_enabled
+      gpgcheck new_resource.gpgcheck
+      gpgkey new_resource.gpgkey
+    end
+  else
+    # use modules on C8 / Fedora
+    yum_remi_modular 'default'
+
+    dnf_module 'php:remi-8.2'
+  end
+end

--- a/test/integration/inspec/controls/php_spec.rb
+++ b/test/integration/inspec/controls/php_spec.rb
@@ -35,12 +35,15 @@ control 'php' do
                    when 'amazon'
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
                    when 'fedora'
-                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2022'
                    else # rhel
-                     if os.release.to_i == 7
+                     case os.release.to_i
+                     when 7
                        'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
-                     else
+                     when 8
                        'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
+                     when 9
+                       'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
                      end
                    end
       end

--- a/test/integration/inspec/controls/remi_modular.rb
+++ b/test/integration/inspec/controls/remi_modular.rb
@@ -24,9 +24,14 @@ control 'remi-modular' do
                  when 'amazon'
                    'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
                  when 'fedora'
-                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2022'
                  else # rhel
-                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
+                   case os.release.to_i
+                   when 8
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
+                   when 9
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+                   end
                  end
     end
   end

--- a/test/integration/inspec/controls/remi_safe_spec.rb
+++ b/test/integration/inspec/controls/remi_safe_spec.rb
@@ -29,12 +29,15 @@ control 'remi-safe' do
                  when 'amazon'
                    'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
                  when 'fedora'
-                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2022'
                  else # rhel
-                   if os.release.to_i == 7
+                   case os.release.to_i
+                   when 7
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
-                   else
+                   when 8
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
+                   when 9
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
                    end
                  end
     end

--- a/test/integration/inspec/controls/remi_spec.rb
+++ b/test/integration/inspec/controls/remi_spec.rb
@@ -27,12 +27,15 @@ control 'remi' do
                  when 'amazon'
                    'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
                  when 'fedora'
-                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2022'
                  else # rhel
-                   if os.release.to_i == 7
+                   case os.release.to_i
+                   when 7
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
-                   else
+                   when 8
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
+                   when 9
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
                    end
                  end
     end

--- a/test/integration/inspec/controls/remi_test_spec.rb
+++ b/test/integration/inspec/controls/remi_test_spec.rb
@@ -27,12 +27,15 @@ control 'remi-test' do
                  when 'amazon'
                    'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
                  when 'fedora'
-                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2022'
                  else # rhel
-                   if os.release.to_i == 7
+                   case os.release.to_i
+                   when 7
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi'
-                   else
+                   when 8
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
+                   when 9
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
                    end
                  end
     end


### PR DESCRIPTION
- Add `remi_php82` resource for supporting PHP 8.2
- Add support for AlmaLinux 9, CentOS Stream 9 and Rocky Linux 9
- Remove remaining references to CentOS 8
- Fix CI and update tests

This supersedes #45 

Signed-off-by: Lance Albertson <lance@osuosl.org>
