### PR TITLE
Add support for AlmaLinux 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
           - almalinux-8
           - almalinux-9
           - centos-stream-9
-          - fedora-latest
+            # - fedora-latest
+            # needs modifications for dnf5
           - rockylinux-8
           - rockylinux-9
         suite:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum-remi-chef  coo
 
 ## Unreleased
 
+- Add support for AlmaLinux 10
+
 ## 8.0.0 - *2024-10-24*
 
 - Add support for PHP 8.3 and 8.4

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following platforms and PHP versions are supported, as per [upstream](https:
 | --------------- | --- | --- | --- | --- | --- | --- | --- | --- |
 | AlmaLinux 8     | M   | M   | M   | M   | M   | M   | M   | M   |
 | AlmaLinux 9     |     |     | M   | M   | M   | M   | M   | M   |
+| AlmaLinux 10    |     |     | M   | M   | M   | M   | M   | M   |
 | CentOS Stream 9 |     |     | M   | M   | M   | M   | M   | M   |
 | Fedora (latest) |     |     |     |     | M   | M   | M   | M   |
 | Rocky Linux 8   | M   | M   | M   | M   | M   | M   | M   | M   |

--- a/attributes/remi-gpgkey.rb
+++ b/attributes/remi-gpgkey.rb
@@ -6,8 +6,10 @@ default['yum-remi-chef']['gpgkey'] =
     case node['platform_version'].to_i
     when 38, 39
       'https://rpms.remirepo.net/RPM-GPG-KEY-remi2023'
-    when 40
+    when 40, 41
       'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
+    when 42
+      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2025'
     else
       Chef::Log.fatal("Fedora #{node['platform_version'].to_i} is not currently supported by this cookbook")
     end
@@ -17,5 +19,7 @@ default['yum-remi-chef']['gpgkey'] =
       'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
     when 9
       'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+    when 10
+      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
     end
   end

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -17,6 +17,11 @@ platforms:
       image: dokken/almalinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: almalinux-10
+    driver:
+      image: dokken/almalinux-10
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: amazonlinux-2023
     driver:
       image: dokken/amazonlinux-2023

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -17,6 +17,7 @@ verifier:
 platforms:
   - name: almalinux-8
   - name: almalinux-9
+  - name: almalinux-10
   - name: amazonlinux-2023
   - name: centos-7
   - name: centos-stream-8

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,6 +19,7 @@ verifier:
 platforms:
   - name: almalinux-8
   - name: almalinux-9
+  - name: almalinux-10
   - name: centos-stream-9
   - name: fedora-latest
   - name: rockylinux-8
@@ -71,6 +72,7 @@ suites:
         version: '7.2'
     excludes:
       - almalinux-9
+      - almalinux-10
       - centos-stream-9
       - fedora-latest
       - rockylinux-9
@@ -90,6 +92,7 @@ suites:
         version: '7.3'
     excludes:
       - almalinux-9
+      - almalinux-10
       - centos-stream-9
       - fedora-latest
       - rockylinux-9

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -11,8 +11,10 @@ module YumRemiChef
           case node['platform_version'].to_i
           when 38, 39
             'https://rpms.remirepo.net/RPM-GPG-KEY-remi2023'
-          when 40
+          when 40, 41
             'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
+          when 42
+            'https://rpms.remirepo.net/RPM-GPG-KEY-remi2025'
           end
         when 'rhel'
           case node['platform_version'].to_i
@@ -20,6 +22,8 @@ module YumRemiChef
             'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
           when 9
             'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+          when 10
+            'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
           end
         end
       end

--- a/spec/remi_modular_spec.rb
+++ b/spec/remi_modular_spec.rb
@@ -29,4 +29,16 @@ describe 'yum-remi-chef::remi-modular' do
       )
     end
   end
+
+  context 'on AlmaLinux 10' do
+    platform 'almalinux', '10'
+
+    it do
+      is_expected.to create_yum_repository('remi-modular').with(
+        mirrorlist: 'http://cdn.remirepo.net/enterprise/10/modular/$basearch/mirror',
+        gpgkey: 'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024',
+        enabled: true
+      )
+    end
+  end
 end

--- a/spec/remi_php74_spec.rb
+++ b/spec/remi_php74_spec.rb
@@ -26,4 +26,12 @@ describe 'yum-remi-chef::remi-php74' do
     it { is_expected.to create_yum_repository('remi-modular') }
     it { is_expected.to switch_to_dnf_module('php:remi-7.4') }
   end
+
+  context 'on AlmaLinux 10' do
+    platform 'almalinux', '10'
+
+    it { is_expected.to create_yum_repository('remi-safe') }
+    it { is_expected.to create_yum_repository('remi-modular') }
+    it { is_expected.to switch_to_dnf_module('php:remi-7.4') }
+  end
 end

--- a/spec/remi_php80_spec.rb
+++ b/spec/remi_php80_spec.rb
@@ -26,4 +26,12 @@ describe 'yum-remi-chef::remi-php80' do
     it { is_expected.to create_yum_repository('remi-modular') }
     it { is_expected.to switch_to_dnf_module('php:remi-8.0') }
   end
+
+  context 'on AlmaLinux 10' do
+    platform 'almalinux', '10'
+
+    it { is_expected.to create_yum_repository('remi-safe') }
+    it { is_expected.to create_yum_repository('remi-modular') }
+    it { is_expected.to switch_to_dnf_module('php:remi-8.0') }
+  end
 end

--- a/spec/remi_php81_spec.rb
+++ b/spec/remi_php81_spec.rb
@@ -26,4 +26,12 @@ describe 'yum-remi-chef::remi-php81' do
     it { is_expected.to create_yum_repository('remi-modular') }
     it { is_expected.to switch_to_dnf_module('php:remi-8.1') }
   end
+
+  context 'on AlmaLinux 10' do
+    platform 'almalinux', '10'
+
+    it { is_expected.to create_yum_repository('remi-safe') }
+    it { is_expected.to create_yum_repository('remi-modular') }
+    it { is_expected.to switch_to_dnf_module('php:remi-8.1') }
+  end
 end

--- a/spec/remi_php82_spec.rb
+++ b/spec/remi_php82_spec.rb
@@ -26,4 +26,12 @@ describe 'yum-remi-chef::remi-php82' do
     it { is_expected.to create_yum_repository('remi-modular') }
     it { is_expected.to switch_to_dnf_module('php:remi-8.2') }
   end
+
+  context 'on AlmaLinux 10' do
+    platform 'almalinux', '10'
+
+    it { is_expected.to create_yum_repository('remi-safe') }
+    it { is_expected.to create_yum_repository('remi-modular') }
+    it { is_expected.to switch_to_dnf_module('php:remi-8.2') }
+  end
 end

--- a/spec/remi_php83_spec.rb
+++ b/spec/remi_php83_spec.rb
@@ -26,4 +26,12 @@ describe 'yum-remi-chef::remi-php83' do
     it { is_expected.to create_yum_repository('remi-modular') }
     it { is_expected.to switch_to_dnf_module('php:remi-8.3') }
   end
+
+  context 'on AlmaLinux 10' do
+    platform 'almalinux', '10'
+
+    it { is_expected.to create_yum_repository('remi-safe') }
+    it { is_expected.to create_yum_repository('remi-modular') }
+    it { is_expected.to switch_to_dnf_module('php:remi-8.3') }
+  end
 end

--- a/spec/remi_php84_spec.rb
+++ b/spec/remi_php84_spec.rb
@@ -26,4 +26,12 @@ describe 'yum-remi-chef::remi-php84' do
     it { is_expected.to create_yum_repository('remi-modular') }
     it { is_expected.to switch_to_dnf_module('php:remi-8.4') }
   end
+
+  context 'on AlmaLinux 10' do
+    platform 'almalinux', '10'
+
+    it { is_expected.to create_yum_repository('remi-safe') }
+    it { is_expected.to create_yum_repository('remi-modular') }
+    it { is_expected.to switch_to_dnf_module('php:remi-8.4') }
+  end
 end

--- a/spec/remi_safe_spec.rb
+++ b/spec/remi_safe_spec.rb
@@ -6,7 +6,7 @@ describe 'yum-remi-chef::remi-safe' do
   default_attributes['yum']['remi-safe-debuginfo']['enabled'] = true
   default_attributes['yum']['remi-safe-debuginfo']['managed'] = true
 
-  %w(8 9).each do |version|
+  %w(8 9 10).each do |version|
     context "on AlmaLinux #{version}" do
       platform 'almalinux', version
 

--- a/spec/remi_spec.rb
+++ b/spec/remi_spec.rb
@@ -6,7 +6,7 @@ describe 'yum-remi-chef::remi' do
   default_attributes['yum']['remi-debuginfo']['enabled'] = true
   default_attributes['yum']['remi-debuginfo']['managed'] = true
 
-  %w(8 9).each do |version|
+  %w(8 9 10).each do |version|
     context "on AlmaLinux #{version}" do
       platform 'almalinux', version
 

--- a/spec/remi_test_spec.rb
+++ b/spec/remi_test_spec.rb
@@ -8,7 +8,7 @@ describe 'yum-remi-chef::remi-test' do
   default_attributes['yum']['remi-test-debuginfo']['enabled'] = true
   default_attributes['yum']['remi-test-debuginfo']['managed'] = true
 
-  %w(8 9).each do |version|
+  %w(8 9 10).each do |version|
     context "on AlmaLinux #{version}" do
       platform 'almalinux', version
 

--- a/test/integration/inspec/controls/remi_modular.rb
+++ b/test/integration/inspec/controls/remi_modular.rb
@@ -19,13 +19,20 @@ control 'remi-modular' do
     its('remi-modular.gpgkey') do
       should cmp case os.name
                  when 'fedora'
-                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2023'
+                   case os.release.to_i
+                   when 40, 41
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
+                   when 42
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2025'
+                   end
                  else # rhel
                    case os.release.to_i
                    when 8
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
                    when 9
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+                   when 10
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
                    end
                  end
     end

--- a/test/integration/inspec/controls/remi_safe_spec.rb
+++ b/test/integration/inspec/controls/remi_safe_spec.rb
@@ -23,7 +23,12 @@ control 'remi-safe' do
     its('remi-safe.gpgkey') do
       should cmp case os.name
                  when 'fedora'
-                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2023'
+                   case os.release.to_i
+                   when 40, 41
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
+                   when 42
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2025'
+                   end
                  else # rhel
                    case os.release.to_i
                    when 7
@@ -32,6 +37,8 @@ control 'remi-safe' do
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
                    when 9
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+                   when 10
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
                    end
                  end
     end

--- a/test/integration/inspec/controls/remi_spec.rb
+++ b/test/integration/inspec/controls/remi_spec.rb
@@ -19,13 +19,20 @@ control 'remi' do
     its('remi.gpgkey') do
       should cmp case os.name
                  when 'fedora'
-                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
+                   case os.release.to_i
+                   when 40, 41
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
+                   when 42
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2025'
+                   end
                  else # rhel
                    case os.release.to_i
                    when 8
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
                    when 9
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+                   when 10
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
                    end
                  end
     end

--- a/test/integration/inspec/controls/remi_test_spec.rb
+++ b/test/integration/inspec/controls/remi_test_spec.rb
@@ -19,13 +19,20 @@ control 'remi-test' do
     its('remi-test.gpgkey') do
       should cmp case os.name
                  when 'fedora'
-                   'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
+                   case os.release.to_i
+                   when 40, 41
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
+                   when 42
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2025'
+                   end
                  else # rhel
                    case os.release.to_i
                    when 8
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2018'
                    when 9
                      'https://rpms.remirepo.net/RPM-GPG-KEY-remi2021'
+                   when 10
+                     'https://rpms.remirepo.net/RPM-GPG-KEY-remi2024'
                    end
                  end
     end


### PR DESCRIPTION
# Description

The changes allow this cookbook to be used on AlmaLinux 10. Fedora CI was disabled because the cookbook does not work with dnf5.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
